### PR TITLE
Use dim foreground for comments

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -270,7 +270,7 @@ fn syntax_highlighting(builder: &mut ThemeBuilder, palette: &Palette) {
 
     builder.add_rules(
         &[Semantic("comment"), Textmate("comment")],
-        (palette.base(BaseScale::BrightFg), FontStyle::Italic),
+        (palette.base(BaseScale::DimFg), FontStyle::Italic),
     );
 
     builder.add_rules(
@@ -280,7 +280,7 @@ fn syntax_highlighting(builder: &mut ThemeBuilder, palette: &Palette) {
             Textmate("comment.block.documentation"),
             Textmate("comment.block.javadoc"),
         ],
-        palette.base(BaseScale::BrightFg),
+        palette.base(BaseScale::DimFg),
     );
 
     builder.add_rules(

--- a/themes/sema chroma-color-theme.json
+++ b/themes/sema chroma-color-theme.json
@@ -174,11 +174,11 @@
 			"fontStyle": ""
 		},
 		"comment": {
-			"foreground": "#FFFFFF",
+			"foreground": "#949494",
 			"italic": true
 		},
 		"comment.documentation": {
-			"foreground": "#FFFFFF",
+			"foreground": "#949494",
 			"fontStyle": ""
 		},
 		"*.attribute": {
@@ -493,28 +493,28 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#FFFFFF",
+				"foreground": "#949494",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "comment.line.documentation",
 			"settings": {
-				"foreground": "#FFFFFF",
+				"foreground": "#949494",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.documentation",
 			"settings": {
-				"foreground": "#FFFFFF",
+				"foreground": "#949494",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.javadoc",
 			"settings": {
-				"foreground": "#FFFFFF",
+				"foreground": "#949494",
 				"fontStyle": ""
 			}
 		},

--- a/themes/sema light chroma-color-theme.json
+++ b/themes/sema light chroma-color-theme.json
@@ -174,11 +174,11 @@
 			"fontStyle": ""
 		},
 		"comment": {
-			"foreground": "#161616",
+			"foreground": "#696969",
 			"italic": true
 		},
 		"comment.documentation": {
-			"foreground": "#161616",
+			"foreground": "#696969",
 			"fontStyle": ""
 		},
 		"*.attribute": {
@@ -493,28 +493,28 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#161616",
+				"foreground": "#696969",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "comment.line.documentation",
 			"settings": {
-				"foreground": "#161616",
+				"foreground": "#696969",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.documentation",
 			"settings": {
-				"foreground": "#161616",
+				"foreground": "#696969",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.javadoc",
 			"settings": {
-				"foreground": "#161616",
+				"foreground": "#696969",
 				"fontStyle": ""
 			}
 		},

--- a/themes/sema light soft chroma-color-theme.json
+++ b/themes/sema light soft chroma-color-theme.json
@@ -174,11 +174,11 @@
 			"fontStyle": ""
 		},
 		"comment": {
-			"foreground": "#2E2E2E",
+			"foreground": "#757575",
 			"italic": true
 		},
 		"comment.documentation": {
-			"foreground": "#2E2E2E",
+			"foreground": "#757575",
 			"fontStyle": ""
 		},
 		"*.attribute": {
@@ -493,28 +493,28 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#2E2E2E",
+				"foreground": "#757575",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "comment.line.documentation",
 			"settings": {
-				"foreground": "#2E2E2E",
+				"foreground": "#757575",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.documentation",
 			"settings": {
-				"foreground": "#2E2E2E",
+				"foreground": "#757575",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.javadoc",
 			"settings": {
-				"foreground": "#2E2E2E",
+				"foreground": "#757575",
 				"fontStyle": ""
 			}
 		},

--- a/themes/sema light soft-color-theme.json
+++ b/themes/sema light soft-color-theme.json
@@ -174,11 +174,11 @@
 			"fontStyle": ""
 		},
 		"comment": {
-			"foreground": "#2E2E2E",
+			"foreground": "#757575",
 			"italic": true
 		},
 		"comment.documentation": {
-			"foreground": "#2E2E2E",
+			"foreground": "#757575",
 			"fontStyle": ""
 		},
 		"*.attribute": {
@@ -493,28 +493,28 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#2E2E2E",
+				"foreground": "#757575",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "comment.line.documentation",
 			"settings": {
-				"foreground": "#2E2E2E",
+				"foreground": "#757575",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.documentation",
 			"settings": {
-				"foreground": "#2E2E2E",
+				"foreground": "#757575",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.javadoc",
 			"settings": {
-				"foreground": "#2E2E2E",
+				"foreground": "#757575",
 				"fontStyle": ""
 			}
 		},

--- a/themes/sema light-color-theme.json
+++ b/themes/sema light-color-theme.json
@@ -174,11 +174,11 @@
 			"fontStyle": ""
 		},
 		"comment": {
-			"foreground": "#161616",
+			"foreground": "#696969",
 			"italic": true
 		},
 		"comment.documentation": {
-			"foreground": "#161616",
+			"foreground": "#696969",
 			"fontStyle": ""
 		},
 		"*.attribute": {
@@ -493,28 +493,28 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#161616",
+				"foreground": "#696969",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "comment.line.documentation",
 			"settings": {
-				"foreground": "#161616",
+				"foreground": "#696969",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.documentation",
 			"settings": {
-				"foreground": "#161616",
+				"foreground": "#696969",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.javadoc",
 			"settings": {
-				"foreground": "#161616",
+				"foreground": "#696969",
 				"fontStyle": ""
 			}
 		},

--- a/themes/sema soft chroma-color-theme.json
+++ b/themes/sema soft chroma-color-theme.json
@@ -174,11 +174,11 @@
 			"fontStyle": ""
 		},
 		"comment": {
-			"foreground": "#EEEEEE",
+			"foreground": "#959595",
 			"italic": true
 		},
 		"comment.documentation": {
-			"foreground": "#EEEEEE",
+			"foreground": "#959595",
 			"fontStyle": ""
 		},
 		"*.attribute": {
@@ -493,28 +493,28 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#EEEEEE",
+				"foreground": "#959595",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "comment.line.documentation",
 			"settings": {
-				"foreground": "#EEEEEE",
+				"foreground": "#959595",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.documentation",
 			"settings": {
-				"foreground": "#EEEEEE",
+				"foreground": "#959595",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.javadoc",
 			"settings": {
-				"foreground": "#EEEEEE",
+				"foreground": "#959595",
 				"fontStyle": ""
 			}
 		},

--- a/themes/sema soft-color-theme.json
+++ b/themes/sema soft-color-theme.json
@@ -174,11 +174,11 @@
 			"fontStyle": ""
 		},
 		"comment": {
-			"foreground": "#EEEEEE",
+			"foreground": "#959595",
 			"italic": true
 		},
 		"comment.documentation": {
-			"foreground": "#EEEEEE",
+			"foreground": "#959595",
 			"fontStyle": ""
 		},
 		"*.attribute": {
@@ -493,28 +493,28 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#EEEEEE",
+				"foreground": "#959595",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "comment.line.documentation",
 			"settings": {
-				"foreground": "#EEEEEE",
+				"foreground": "#959595",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.documentation",
 			"settings": {
-				"foreground": "#EEEEEE",
+				"foreground": "#959595",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.javadoc",
 			"settings": {
-				"foreground": "#EEEEEE",
+				"foreground": "#959595",
 				"fontStyle": ""
 			}
 		},

--- a/themes/sema-color-theme.json
+++ b/themes/sema-color-theme.json
@@ -174,11 +174,11 @@
 			"fontStyle": ""
 		},
 		"comment": {
-			"foreground": "#FFFFFF",
+			"foreground": "#949494",
 			"italic": true
 		},
 		"comment.documentation": {
-			"foreground": "#FFFFFF",
+			"foreground": "#949494",
 			"fontStyle": ""
 		},
 		"*.attribute": {
@@ -493,28 +493,28 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#FFFFFF",
+				"foreground": "#949494",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "comment.line.documentation",
 			"settings": {
-				"foreground": "#FFFFFF",
+				"foreground": "#949494",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.documentation",
 			"settings": {
-				"foreground": "#FFFFFF",
+				"foreground": "#949494",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "comment.block.javadoc",
 			"settings": {
-				"foreground": "#FFFFFF",
+				"foreground": "#949494",
 				"fontStyle": ""
 			}
 		},


### PR DESCRIPTION
This PR dims comment foreground to further differentiate them from code. I understand it might not be everyone's preference.

Great work on the theme btw. I've been using it for around three months and can safely say that sema is my favorite theme ever!

<img width="525" alt="Screen Shot 2022-07-25 at 10 53 34 AM" src="https://user-images.githubusercontent.com/6402908/180806825-fb13f12e-4941-434d-9487-90ac2bac1a2e.png">

<img width="525" alt="Screen Shot 2022-07-25 at 10 54 06 AM" src="https://user-images.githubusercontent.com/6402908/180806951-6950bbc3-1c5b-4bfb-8b40-f9e9eed36ee7.png">